### PR TITLE
aliasing "update" with "update-todo" for packwerk parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 description = "Welcome! Please see https://github.com/rubyatscale/pks for more information!"
 license = "MIT"

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -83,7 +83,8 @@ enum Command {
     },
 
     #[clap(
-        about = "Update package_todo.yml files with the current violations"
+        about = "Update package_todo.yml files with the current violations",
+        alias = "update-todo"
     )]
     Update,
 

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -6,14 +6,24 @@ mod common;
 use pretty_assertions::assert_eq;
 
 #[test]
-// This and the next test are run in serial because they both use the same fixtures.
 #[serial]
-fn test_update() -> Result<(), Box<dyn Error>> {
+// This and the next test are run in serial because they both use the same fixtures.
+fn update() -> Result<(), Box<dyn Error>> {
+    test_update("update")
+}
+
+#[test]
+#[serial]
+fn update_todo() -> Result<(), Box<dyn Error>> {
+    test_update("update-todo")
+}
+
+fn test_update(command: &str) -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("pks")?
         .arg("--project-root")
         .arg("tests/fixtures/simple_app")
         .arg("--debug")
-        .arg("update")
+        .arg(command)
         .assert()
         .success()
         .stdout(predicate::str::contains(


### PR DESCRIPTION
User's of packwerk sometimes try to execute `bin/pks update-todo`. With this update, `update-todo` will execute `update`