### PR TITLE
Renaming unnecessary-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 description = "Welcome! Please see https://github.com/rubyatscale/pks for more information!"
 license = "MIT"

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -381,13 +381,14 @@ pub(crate) fn check_unnecessary_dependencies(
             "Found 1 unnecessary dependency".to_string()
         } else {
             format!(
-                "Found {} unnecessary dependencies",
+                "Found {} unused dependencies",
                 unnecessary_dependencies.len()
             )
         };
         bail!(
-            "{}. Run command with `--auto-correct` to remove them.",
+            "{}. Run `{} check-unused-dependencies --auto-correct` to remove them.",
             found_message,
+            bin_locater::packs_bin_name(),
         );
     }
 }

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -109,10 +109,11 @@ enum Command {
     },
 
     #[clap(
-        about = "Check for dependencies that when removed produce no violations."
+        about = "Check for dependencies that when removed produce no violations.",
+        alias = "check-unnecessary-dependencies"
     )]
-    CheckUnnecessaryDependencies {
-        #[arg(long)]
+    CheckUnusedDependencies {
+        #[arg(short, long)]
         auto_correct: bool,
     },
 
@@ -263,7 +264,7 @@ pub fn run() -> anyhow::Result<()> {
             packs::validate(&configuration)
             // Err("💡 Please use `packs check` to detect dependency cycles and run other configuration validations".into())
         }
-        Command::CheckUnnecessaryDependencies { auto_correct } => {
+        Command::CheckUnusedDependencies { auto_correct } => {
             packs::check_unnecessary_dependencies(&configuration, auto_correct)
         }
         Command::UpdateDependenciesForConstant { constant } => Ok(


### PR DESCRIPTION
- [x] renaming check-unnecessary-dependencies to `check-unused-dependencies`
- [x] allowing for `-a` for autocorrect
- [x] specifying full command to run for autocorrect when `check-unused-dependencies` fails 