### PR TITLE
CSV output for `pks check`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 description = "Welcome! Please see https://github.com/rubyatscale/pks for more information!"
 license = "MIT"
@@ -27,7 +27,7 @@ path = "src/lib.rs"
 anyhow = { version = "1.0.75", features = [] } # for error handling
 clap = { version = "4.2.1", features = ["derive"] } # cli
 clap_derive = "4.2.0" # cli
-csv = "1.3.0"
+csv = "1.3.0" # csv de/serialize
 itertools = "0.13.0" # tools for iterating over iterable things
 jwalk = "0.8.1" # for walking the file tree
 path-clean = "1.0.1" # Pathname#cleaname in Ruby

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/lib.rs"
 anyhow = { version = "1.0.75", features = [] } # for error handling
 clap = { version = "4.2.1", features = ["derive"] } # cli
 clap_derive = "4.2.0" # cli
+csv = "1.3.0"
 itertools = "0.13.0" # tools for iterating over iterable things
 jwalk = "0.8.1" # for walking the file tree
 path-clean = "1.0.1" # Pathname#cleaname in Ruby

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -64,9 +64,9 @@ pub(crate) trait ValidatorInterface {
 
 #[derive(Debug, PartialEq)]
 pub struct CheckAllResult {
-    reportable_violations: HashSet<Violation>,
-    stale_violations: Vec<ViolationIdentifier>,
-    strict_mode_violations: HashSet<Violation>,
+    pub reportable_violations: HashSet<Violation>,
+    pub stale_violations: Vec<ViolationIdentifier>,
+    pub strict_mode_violations: HashSet<Violation>,
 }
 
 impl CheckAllResult {

--- a/src/packs/csv.rs
+++ b/src/packs/csv.rs
@@ -1,0 +1,50 @@
+use itertools::chain;
+
+use super::checker::{build_strict_violation_message, CheckAllResult};
+
+pub fn write_csv<W: std::io::Write>(
+    result: &CheckAllResult,
+    writer: W,
+) -> anyhow::Result<()> {
+    let mut wtr = csv::Writer::from_writer(writer);
+    wtr.write_record([
+        "Violation",
+        "Strict?",
+        "File",
+        "Constant",
+        "Referencing Pack",
+        "Defining Pack",
+        "Message",
+    ])?;
+
+    if !&result.reportable_violations.is_empty()
+        || !&result.strict_mode_violations.is_empty()
+    {
+        let all = chain!(
+            &result.reportable_violations,
+            &result.strict_mode_violations
+        );
+
+        for violation in all {
+            let identifier = &violation.identifier;
+            let message = if violation.identifier.strict {
+                build_strict_violation_message(&violation.identifier)
+            } else {
+                violation.message.to_string()
+            };
+            wtr.serialize((
+                &identifier.violation_type,
+                &identifier.strict,
+                &identifier.file,
+                &identifier.constant_name,
+                &identifier.referencing_pack_name,
+                &identifier.defining_pack_name,
+                &message,
+            ))?;
+        }
+    } else {
+        wtr.serialize(("No violations detected!", "", "", "", "", "", ""))?;
+    }
+    wtr.flush()?;
+    Ok(())
+}

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -167,6 +167,25 @@ fn test_check_with_package_todo_file() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_check_with_package_todo_file_csv() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("pks")?
+        .arg("--project-root")
+        .arg("tests/fixtures/contains_package_todo")
+        .arg("--debug")
+        .arg("check")
+        .arg("-o")
+        .arg("csv")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Violation,Strict?,File,Constant,Referencing Pack,Defining Pack,Message"))
+        .stdout(predicate::str::contains("No violations detected!"));
+
+    common::teardown();
+
+    Ok(())
+}
+
+#[test]
 fn test_check_with_package_todo_file_ignoring_recorded_violations(
 ) -> Result<(), Box<dyn Error>> {
     let output = Command::cargo_bin("pks")?
@@ -302,6 +321,26 @@ fn test_check_with_strict_mode() -> Result<(), Box<dyn Error>> {
         ))
         .stdout(predicate::str::contains(
             "packs/foo cannot have dependency violations on packs/bar because strict mode is enabled for dependency violations in the enforcing pack's package.yml file",
+        ));
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
+fn test_check_with_strict_mode_output_csv() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("pks")
+        .unwrap()
+        .arg("--project-root")
+        .arg("tests/fixtures/uses_strict_mode")
+        .arg("check")
+        .arg("-o")
+        .arg("csv")
+        .assert()
+        .stdout(predicate::str::contains("Violation,Strict?,File,Constant,Referencing Pack,Defining Pack,Message"))
+        .stdout(predicate::str::contains("privacy,true,packs/foo/app/services/foo.rb,::Bar,packs/foo,packs/bar,packs/foo cannot have privacy violations on packs/bar because strict mode is enabled for privacy violations in the enforcing pack\'s package.yml file"))
+        .stdout(predicate::str::contains(
+            "privacy,true,packs/foo/app/services/foo.rb,::Bar,packs/foo,packs/bar,packs/foo cannot have privacy violations on packs/bar because strict mode is enabled for privacy violations in the enforcing pack\'s package.yml file",
         ));
 
     common::teardown();


### PR DESCRIPTION
# Why
We are moving towards using the `--experimental` flag in our very large monolith. There are many many violations as a result of `bin/pks -e check` and we needed a way to wrangle them into a spreadsheet.

# How
Implemented a new `--output-format` flag for `check`.

```bash
bin/pks check -o csv > check-results.csv
```
In our case, we use the experimental flag too.
```bash
bin/pks -e check -o csv > experimental-check-results.csv
```

Note: the csv result are written to standard out. You can redirect the output to a file of your choosing.