### PR TITLE
Keep necessary quotes around private constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 description = "Welcome! Please see https://github.com/rubyatscale/pks for more information!"
 license = "MIT"

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -405,6 +405,8 @@ pub fn serialize_pack(pack: &Pack) -> anyhow::Result<String> {
     }
 }
 
+// serde_yaml doesn't add quotes around all constants, which isn't a problem
+//unless the constant starts with ::
 fn add_back_necessary_quotes(
     serialized_pack: String,
 ) -> anyhow::Result<String> {


### PR DESCRIPTION
`pks` uses the [serde_yml](https://crates.io/crates/serde_yml/0.0.6) crate to de/serialize yml.

This isn't a problem unless the constant begins with `::`.

This PR adds the quotes back after yml serialization.

```yml
ignored_private_constants:
- "::Quotes::Are::Required"
- "Not::Required"
```
In the above example, this PR will keep the quotes for `"::Quotes::Are::Required"`, but continue to strip them off for `Not::Required`