### PR TITLE
Add json output format to check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,34 +24,35 @@ name = "packs"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { version = "1.0.75", features = [] } # for error handling
-clap = { version = "4.2.1", features = ["derive"] } # cli
-clap_derive = "4.2.0" # cli
-csv = "1.3.0" # csv de/serialize
-itertools = "0.13.0" # tools for iterating over iterable things
-jwalk = "0.8.1" # for walking the file tree
-path-clean = "1.0.1" # Pathname#cleaname in Ruby
-rayon = "1.7.0" # for parallel iteration
+anyhow = { version = "1.0.75", features = [] }                         # for error handling
+clap = { version = "4.2.1", features = ["derive"] }                    # cli
+clap_derive = "4.2.0"                                                  # cli
+csv = "1.3.0"                                                          # csv de/serialize
+itertools = "0.13.0"                                                   # tools for iterating over iterable things
+jwalk = "0.8.1"                                                        # for walking the file tree
+path-clean = "1.0.1"                                                   # Pathname#cleaname in Ruby
+rayon = "1.7.0"                                                        # for parallel iteration
 regex = "1.7.3"
-serde = { version = "~1", features = ["derive"] } # de(serialization)
-serde_yaml = "0.9.19" # de(serialization)
-serde_json = "1.0.96" # de(serialization)
-serde_magnus = "0.7.0" # permits a ruby gem to interface with this library
-tracing = "0.1.37" # logging
+serde = { version = "~1", features = ["derive"] }                      # de(serialization)
+serde_yaml = "0.9.19"                                                  # de(serialization)
+serde_json = "1.0.96"                                                  # de(serialization)
+serde_magnus = "0.7.0"                                                 # permits a ruby gem to interface with this library
+tracing = "0.1.37"                                                     # logging
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] } # logging
-glob = "0.3.1" # globbing
-globset = "0.4.10" # globbing
-lib-ruby-parser = "4.0.6" # ruby parser
-md5 = "0.7.0" # md5 hashing to take and compare md5 digests of file contents to ensure cache validity
-line-col = "0.2.1" # for creating source maps of violations
-ruby_inflector = '0.0.8' # for inflecting strings, e.g. turning `has_many :companies` into `Company`
-petgraph = "0.6.3" # for running graph algorithms (e.g. does the dependency graph contain a cycle?)
+glob = "0.3.1"                                                         # globbing
+globset = "0.4.10"                                                     # globbing
+lib-ruby-parser = "4.0.6"                                              # ruby parser
+md5 = "0.7.0"                                                          # md5 hashing to take and compare md5 digests of file contents to ensure cache validity
+line-col = "0.2.1"                                                     # for creating source maps of violations
+ruby_inflector = '0.0.8'                                               # for inflecting strings, e.g. turning `has_many :companies` into `Company`
+petgraph = "0.6.3"                                                     # for running graph algorithms (e.g. does the dependency graph contain a cycle?)
 fnmatch-regex2 = "0.3.0"
 strip-ansi-escapes = "0.2.0"
 
 [dev-dependencies]
-assert_cmd = "2.1.1" # testing CLI
-rusty-hook = "^0.11.2" # git hooks
-predicates = "3.0.2" # kind of like rspec assertions
+assert_cmd = "2.1.1"        # testing CLI
+jsonschema = "0.27"         # JSON schema validation
+rusty-hook = "^0.11.2"      # git hooks
+predicates = "3.0.2"        # kind of like rspec assertions
 pretty_assertions = "1.3.0" # Shows a more readable diff when comparing objects
-serial_test = "3.1.1" # Run specific tests in serial
+serial_test = "3.1.1"       # Run specific tests in serial

--- a/schema/check-output.json
+++ b/schema/check-output.json
@@ -44,6 +44,8 @@
       "required": [
         "violation_type",
         "file",
+        "line",
+        "column",
         "constant_name",
         "referencing_pack_name",
         "defining_pack_name",
@@ -54,6 +56,8 @@
       "properties": {
         "violation_type": { "$ref": "#/$defs/ViolationType" },
         "file": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 0 },
         "constant_name": { "type": "string" },
         "referencing_pack_name": { "type": "string" },
         "defining_pack_name": { "type": "string" },

--- a/schema/check-output.json
+++ b/schema/check-output.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "pks check JSON output",
+  "type": "object",
+  "required": ["violations", "stale_todos", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "violations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Violation" }
+    },
+    "stale_todos": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/StaleTodo" }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "violation_count",
+        "stale_todo_count",
+        "strict_violation_count",
+        "success"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "violation_count": { "type": "integer", "minimum": 0 },
+        "stale_todo_count": { "type": "integer", "minimum": 0 },
+        "strict_violation_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of violations where strict=true (subset of violation_count)"
+        },
+        "success": { "type": "boolean" }
+      }
+    }
+  },
+  "$defs": {
+    "ViolationType": {
+      "type": "string",
+      "enum": ["dependency", "privacy", "visibility", "layer", "folder_privacy"]
+    },
+    "Violation": {
+      "type": "object",
+      "required": [
+        "violation_type",
+        "file",
+        "constant_name",
+        "referencing_pack_name",
+        "defining_pack_name",
+        "strict",
+        "message"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "violation_type": { "$ref": "#/$defs/ViolationType" },
+        "file": { "type": "string" },
+        "constant_name": { "type": "string" },
+        "referencing_pack_name": { "type": "string" },
+        "defining_pack_name": { "type": "string" },
+        "strict": { "type": "boolean" },
+        "message": { "type": "string" }
+      }
+    },
+    "StaleTodo": {
+      "type": "object",
+      "required": [
+        "violation_type",
+        "file",
+        "constant_name",
+        "referencing_pack_name",
+        "defining_pack_name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "violation_type": { "$ref": "#/$defs/ViolationType" },
+        "file": { "type": "string" },
+        "constant_name": { "type": "string" },
+        "referencing_pack_name": { "type": "string" },
+        "defining_pack_name": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,14 @@ pub fn main() -> ExitCode {
     match cli::run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
-            // ViolationsFound already printed its output; other errors need display
-            if e.downcast_ref::<cli::ViolationsFound>().is_none() {
+            if e.downcast_ref::<cli::ViolationsFound>().is_some() {
+                // ViolationsFound already printed its output; exit 1 for violations
+                ExitCode::from(1)
+            } else {
+                // Other errors (IO, config, etc.) exit 2; usage errors handled by clap
                 eprintln!("Error: {e:#}");
+                ExitCode::from(2)
             }
-            // Exit 1 for all application errors (violations, config, IO, etc.)
-            // Usage errors are handled by clap with exit code 2
-            ExitCode::from(1)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,17 @@
 use packs::packs::cli;
+use std::process::ExitCode;
 
-pub fn main() -> anyhow::Result<()> {
-    cli::run()
+pub fn main() -> ExitCode {
+    match cli::run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            // ViolationsFound already printed its output; other errors need display
+            if e.downcast_ref::<cli::ViolationsFound>().is_none() {
+                eprintln!("Error: {e:#}");
+            }
+            // Exit 1 for all application errors (violations, config, IO, etc.)
+            // Usage errors are handled by clap with exit code 2
+            ExitCode::from(1)
+        }
+    }
 }

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -41,6 +41,7 @@ pub(crate) use self::parsing::ParsedDefinition;
 pub(crate) use self::parsing::UnresolvedReference;
 use anyhow::bail;
 use cli::OutputFormat;
+use cli::ViolationsFound;
 pub(crate) use configuration::Configuration;
 pub(crate) use package_todo::PackageTodo;
 
@@ -80,9 +81,6 @@ pub fn check(
     match output_format {
         OutputFormat::Packwerk => {
             println!("{}", result);
-            if result.has_violations() {
-                bail!("Violations found!")
-            }
         }
         OutputFormat::CSV => {
             csv::write_csv(&result, std::io::stdout())?;
@@ -90,6 +88,10 @@ pub fn check(
         OutputFormat::JSON => {
             json::write_json(&result, std::io::stdout())?;
         }
+    }
+
+    if result.has_violations() {
+        return Err(ViolationsFound.into());
     }
 
     Ok(())

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -13,6 +13,7 @@ pub(crate) mod creator;
 pub(crate) mod csv;
 pub(crate) mod dependencies;
 pub(crate) mod ignored;
+pub(crate) mod json;
 pub(crate) mod monkey_patch_detection;
 pub(crate) mod pack;
 pub(crate) mod parsing;
@@ -85,6 +86,9 @@ pub fn check(
         }
         OutputFormat::CSV => {
             csv::write_csv(&result, std::io::stdout())?;
+        }
+        OutputFormat::JSON => {
+            json::write_json(&result, std::io::stdout())?;
         }
     }
 

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -234,10 +234,12 @@ pub struct ProcessedFile {
     pub definitions: Vec<ParsedDefinition>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default, Eq, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, Default, Eq, Clone, Hash,
+)]
 pub struct SourceLocation {
-    line: usize,
-    column: usize,
+    pub line: usize,
+    pub column: usize,
 }
 
 pub(crate) fn list_definitions(

--- a/src/packs/checker/common_test.rs
+++ b/src/packs/checker/common_test.rs
@@ -54,6 +54,7 @@ pub mod tests {
                 referencing_pack_name: String::from("packs/foo"),
                 defining_pack_name: String::from("packs/bar"),
             },
+            source_location: SourceLocation { line: 3, column: 1 },
         }
     }
 

--- a/src/packs/checker/pack_checker.rs
+++ b/src/packs/checker/pack_checker.rs
@@ -161,6 +161,7 @@ impl<'a> PackChecker<'a> {
         Ok(Some(Violation {
             message: self.interpolate_violation_message(extra_template_fields),
             identifier: self.violation_identifier(),
+            source_location: self.reference.source_location.clone(),
         }))
     }
 

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -208,9 +208,9 @@ impl Args {
 
 pub fn run() -> anyhow::Result<()> {
     let args = Args::parse();
-    let absolute_root = args
-        .absolute_project_root()
-        .map_err(|e| anyhow::anyhow!("Issue getting absolute_project_root: {}", e))?;
+    let absolute_root = args.absolute_project_root().map_err(|e| {
+        anyhow::anyhow!("Issue getting absolute_project_root: {}", e)
+    })?;
 
     install_logger(args.debug);
 

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -8,6 +8,22 @@ use tracing::debug;
 
 use super::logger::install_logger;
 
+/// Error returned when violations are found during check.
+///
+/// This is a marker type used to distinguish "violations found" (exit 1)
+/// from internal errors (exit 2) following linter conventions (eslint, rubocop, shellcheck).
+#[derive(Debug)]
+pub struct ViolationsFound;
+
+impl std::fmt::Display for ViolationsFound {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Output is already printed; this marker carries no additional message
+        Ok(())
+    }
+}
+
+impl std::error::Error for ViolationsFound {}
+
 /// A CLI to interact with packs
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -194,7 +210,7 @@ pub fn run() -> anyhow::Result<()> {
     let args = Args::parse();
     let absolute_root = args
         .absolute_project_root()
-        .expect("Issue getting absolute_project_root!");
+        .map_err(|e| anyhow::anyhow!("Issue getting absolute_project_root: {}", e))?;
 
     install_logger(args.debug);
 

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -159,6 +159,7 @@ enum Command {
 pub enum OutputFormat {
     Packwerk,
     CSV,
+    JSON,
 }
 
 #[derive(Debug, Args)]

--- a/src/packs/json.rs
+++ b/src/packs/json.rs
@@ -1,0 +1,101 @@
+use itertools::chain;
+use serde::Serialize;
+
+use super::checker::{build_strict_violation_message, CheckAllResult};
+
+#[derive(Serialize)]
+struct JsonOutput<'a> {
+    violations: Vec<JsonViolation<'a>>,
+    stale_todos: Vec<JsonStaleTodo<'a>>,
+    summary: JsonSummary,
+}
+
+#[derive(Serialize)]
+struct JsonViolation<'a> {
+    violation_type: &'a str,
+    file: &'a str,
+    constant_name: &'a str,
+    referencing_pack_name: &'a str,
+    defining_pack_name: &'a str,
+    strict: bool,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct JsonStaleTodo<'a> {
+    violation_type: &'a str,
+    file: &'a str,
+    constant_name: &'a str,
+    referencing_pack_name: &'a str,
+    defining_pack_name: &'a str,
+}
+
+#[derive(Serialize)]
+struct JsonSummary {
+    violation_count: usize,
+    stale_todo_count: usize,
+    strict_violation_count: usize,
+    success: bool,
+}
+
+pub fn write_json<W: std::io::Write>(
+    result: &CheckAllResult,
+    writer: W,
+) -> anyhow::Result<()> {
+    let all_violations = chain!(
+        &result.reportable_violations,
+        &result.strict_mode_violations
+    );
+
+    let violations: Vec<JsonViolation> = all_violations
+        .map(|v| {
+            let message = if v.identifier.strict {
+                build_strict_violation_message(&v.identifier)
+            } else {
+                v.message.clone()
+            };
+            JsonViolation {
+                violation_type: &v.identifier.violation_type,
+                file: &v.identifier.file,
+                constant_name: &v.identifier.constant_name,
+                referencing_pack_name: &v.identifier.referencing_pack_name,
+                defining_pack_name: &v.identifier.defining_pack_name,
+                strict: v.identifier.strict,
+                message,
+            }
+        })
+        .collect();
+
+    let stale_todos: Vec<JsonStaleTodo> = result
+        .stale_violations
+        .iter()
+        .map(|v| JsonStaleTodo {
+            violation_type: &v.violation_type,
+            file: &v.file,
+            constant_name: &v.constant_name,
+            referencing_pack_name: &v.referencing_pack_name,
+            defining_pack_name: &v.defining_pack_name,
+        })
+        .collect();
+
+    let violation_count = violations.len();
+    let stale_todo_count = stale_todos.len();
+    let strict_violation_count = result.strict_mode_violations.len();
+    let success = violation_count == 0
+        && stale_todo_count == 0
+        && strict_violation_count == 0;
+
+    let output = JsonOutput {
+        violations,
+        stale_todos,
+        summary: JsonSummary {
+            violation_count,
+            stale_todo_count,
+            strict_violation_count,
+            success,
+        },
+    };
+
+    serde_json::to_writer(writer, &output)?;
+    Ok(())
+}

--- a/src/packs/json.rs
+++ b/src/packs/json.rs
@@ -1,3 +1,8 @@
+//! JSON output formatter for `pks check -o json`.
+//!
+//! Serializes check results (violations, stale TODOs, and summary) to JSON.
+//! See `schema/check-output.json` for the JSON Schema specification.
+
 use itertools::chain;
 use serde::Serialize;
 

--- a/src/packs/json.rs
+++ b/src/packs/json.rs
@@ -14,6 +14,8 @@ struct JsonOutput<'a> {
 struct JsonViolation<'a> {
     violation_type: &'a str,
     file: &'a str,
+    line: usize,
+    column: usize,
     constant_name: &'a str,
     referencing_pack_name: &'a str,
     defining_pack_name: &'a str,
@@ -57,6 +59,8 @@ pub fn write_json<W: std::io::Write>(
             JsonViolation {
                 violation_type: &v.identifier.violation_type,
                 file: &v.identifier.file,
+                line: v.source_location.line,
+                column: v.source_location.column,
                 constant_name: &v.identifier.constant_name,
                 referencing_pack_name: &v.identifier.referencing_pack_name,
                 defining_pack_name: &v.identifier.defining_pack_name,

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -469,7 +469,7 @@ fn test_check_with_json_output_format_violations() -> Result<(), Box<dyn Error>>
         dependency_violation["defining_pack_name"].as_str().unwrap(),
         "packs/bar"
     );
-    assert_eq!(dependency_violation["strict"].as_bool().unwrap(), false);
+    assert!(!dependency_violation["strict"].as_bool().unwrap());
     assert!(dependency_violation["message"]
         .as_str()
         .unwrap()
@@ -496,7 +496,7 @@ fn test_check_with_json_output_format_violations() -> Result<(), Box<dyn Error>>
         privacy_violation["defining_pack_name"].as_str().unwrap(),
         "packs/bar"
     );
-    assert_eq!(privacy_violation["strict"].as_bool().unwrap(), false);
+    assert!(!privacy_violation["strict"].as_bool().unwrap());
     assert!(privacy_violation["message"]
         .as_str()
         .unwrap()

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -34,7 +34,7 @@ fn test_check_with_privacy_dependency_error_template_overrides(
         .arg("--debug")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -56,7 +56,7 @@ fn test_check() -> Result<(), Box<dyn Error>> {
         .arg("--debug")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -80,7 +80,7 @@ fn test_check_enforce_privacy_disabled() -> Result<(), Box<dyn Error>> {
         .arg("--disable-enforce-privacy")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -103,7 +103,7 @@ fn test_check_enforce_dependency_disabled() -> Result<(), Box<dyn Error>> {
         .arg("--disable-enforce-dependencies")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -126,7 +126,7 @@ fn test_check_with_single_file() -> Result<(), Box<dyn Error>> {
         .arg("check")
         .arg("packs/foo/app/services/foo.rb")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -152,7 +152,7 @@ fn test_check_with_single_file_experimental_parser(
         .arg("check")
         .arg("packs/foo/app/services/foo.rb")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -175,7 +175,7 @@ fn test_check_with_package_todo_file() -> Result<(), Box<dyn Error>> {
         .arg("--debug")
         .arg("check")
         .assert()
-        .success()
+        .code(0)
         .stdout(predicate::str::contains("No violations detected!"));
 
     common::teardown();
@@ -193,7 +193,7 @@ fn test_check_with_package_todo_file_csv() -> Result<(), Box<dyn Error>> {
         .arg("-o")
         .arg("csv")
         .assert()
-        .success()
+        .code(0)
         .stdout(predicate::str::contains("Violation,Strict?,File,Constant,Referencing Pack,Defining Pack,Message"))
         .stdout(predicate::str::contains("No violations detected!"));
 
@@ -212,7 +212,7 @@ fn test_check_with_package_todo_file_ignoring_recorded_violations(
         .arg("check")
         .arg("--ignore-recorded-violations")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -236,7 +236,7 @@ fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
         .arg("--debug")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -258,7 +258,7 @@ fn test_check_with_stale_violations() -> Result<(), Box<dyn Error>> {
         .arg("tests/fixtures/contains_stale_violations")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .stdout(predicate::str::contains(
             "There were stale violations found, please run `packs update`",
         ));
@@ -275,7 +275,7 @@ fn test_check_with_stale_violations_when_file_no_longer_exists(
         .arg("tests/fixtures/contains_stale_violations_no_file")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .stdout(predicate::str::contains(
             "There were stale violations found, please run `packs update`",
         ));
@@ -291,7 +291,7 @@ fn test_check_with_relationship_violations() -> Result<(), Box<dyn Error>> {
         .arg("tests/fixtures/app_with_rails_relationships")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .stdout(predicate::str::contains("2 violation(s) detected:"))
         .stdout(predicate::str::contains("Privacy violation: `::Taco` is private to `packs/baz`, but referenced from `packs/bar`"))
         .stdout(predicate::str::contains("Privacy violation: `::Census` is private to `packs/baz`, but referenced from `packs/bar`"));
@@ -307,7 +307,7 @@ fn test_check_without_stale_violations() -> Result<(), Box<dyn Error>> {
         .arg("tests/fixtures/contains_package_todo")
         .arg("check")
         .assert()
-        .success()
+        .code(0)
         .stdout(
             predicate::str::contains(
                 "There were stale violations found, please run `packs update`",
@@ -326,7 +326,7 @@ fn test_check_with_strict_mode() -> Result<(), Box<dyn Error>> {
         .arg("tests/fixtures/uses_strict_mode")
         .arg("check")
         .assert()
-        .failure()
+        .code(1)
         .stdout(predicate::str::contains(
             "packs/foo cannot have privacy violations on packs/bar because strict mode is enabled for privacy violations in the enforcing pack's package.yml file",
         ))
@@ -347,6 +347,7 @@ fn test_check_with_strict_mode_output_csv() -> Result<(), Box<dyn Error>> {
         .arg("-o")
         .arg("csv")
         .assert()
+        .code(1)
         .stdout(predicate::str::contains("Violation,Strict?,File,Constant,Referencing Pack,Defining Pack,Message"))
         .stdout(predicate::str::contains("privacy,true,packs/foo/app/services/foo.rb,::Bar,packs/foo,packs/bar,packs/foo cannot have privacy violations on packs/bar because strict mode is enabled for privacy violations in the enforcing pack\'s package.yml file"))
         .stdout(predicate::str::contains(
@@ -372,7 +373,7 @@ fn test_check_contents() -> Result<(), Box<dyn Error>> {
         .arg(relative_path)
         .write_stdin(format!("\n\n\n{}", foo_rb_contents))
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -404,7 +405,7 @@ fn test_check_contents_ignoring_recorded_violations(
         .arg(relative_path)
         .write_stdin(format!("\n\n\n{}", foo_rb_contents))
         .assert()
-        .failure()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -427,7 +428,7 @@ fn test_check_with_json_output_format_violations() -> Result<(), Box<dyn Error>>
         .arg("-o")
         .arg("json")
         .assert()
-        .success()
+        .code(1)
         .get_output()
         .stdout
         .clone();
@@ -515,7 +516,7 @@ fn test_check_with_json_output_format_stale_todos() -> Result<(), Box<dyn Error>
         .arg("-o")
         .arg("json")
         .assert()
-        .success()
+        .code(1) // Stale todos are violations that should fail
         .get_output()
         .stdout
         .clone();
@@ -593,7 +594,7 @@ fn test_check_with_json_output_format_empty() -> Result<(), Box<dyn Error>> {
         .arg("-o")
         .arg("json")
         .assert()
-        .success()
+        .code(0)
         .get_output()
         .stdout
         .clone();
@@ -611,5 +612,35 @@ fn test_check_with_json_output_format_empty() -> Result<(), Box<dyn Error>> {
     assert!(json_output["stale_todos"].as_array().unwrap().is_empty());
 
     common::teardown();
+    Ok(())
+}
+
+#[test]
+fn test_check_with_nonexistent_project_root() -> Result<(), Box<dyn Error>> {
+    // Exit code 2 for internal errors (non-existent project root)
+    cargo_bin_cmd!("pks")
+        .arg("--project-root")
+        .arg("tests/fixtures/does_not_exist")
+        .arg("check")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Error:"));
+
+    Ok(())
+}
+
+#[test]
+fn test_check_with_invalid_output_format() -> Result<(), Box<dyn Error>> {
+    // Exit code 2 for argument parsing errors (clap's default)
+    cargo_bin_cmd!("pks")
+        .arg("--project-root")
+        .arg("tests/fixtures/simple_app")
+        .arg("check")
+        .arg("-o")
+        .arg("invalid_format")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid value 'invalid_format'"));
+
     Ok(())
 }


### PR DESCRIPTION
This change adds a json output option and provides a schema to describe the output format. The goal is to be able to programmatically parse the output of `pks check` for other tools like danger.

We decided to split the idea of a stale todo from the idea of a violation, since even though they talk about the same idea, the have different meanings.

- A stale todo is a leftover reference to a problem that no longer exists. The fix requires no work other than running `pks update`. It's a lint warning.
- A violation should be address via a choice by the developer to either repair the violation, change the package config, or add it to the todo.