### PR TITLE
Add cosign binary signing to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,19 @@ jobs:
     needs: release
     runs-on: macos-latest
     if: ${{needs.release.outputs.new_version}}
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Build
         run: cargo build --release --target aarch64-apple-darwin --target x86_64-apple-darwin
 
-      - name: Upload mac universal binary
+      - name: Create mac universal binary
         run: |
           # This combines the intel and m1 binaries into a single binary
           lipo -create -output target/pks target/aarch64-apple-darwin/release/pks target/x86_64-apple-darwin/release/pks
@@ -115,9 +122,13 @@ jobs:
           # Creates artifact for homebrew. -C means run from `target` directory
           tar -czf target/pks-mac.tar.gz -C target pks
 
-          # This tarball is a binary that is executable
-          gh release upload $NEW_VERSION target/pks-mac.tar.gz
+      - name: Sign mac binary with cosign
+        run: |
+          cosign sign-blob --yes --output-signature target/pks-mac.tar.gz.sig target/pks-mac.tar.gz
 
+      - name: Upload mac universal binary and signature
+        run: |
+          gh release upload $NEW_VERSION target/pks-mac.tar.gz target/pks-mac.tar.gz.sig
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ needs.release.outputs.new_version }}
@@ -126,8 +137,15 @@ jobs:
     needs: release
     if: ${{needs.release.outputs.new_version}}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Update local toolchain
         run: |
           cargo install cross
@@ -135,12 +153,21 @@ jobs:
         run: |
           cross build --release --target x86_64-unknown-linux-gnu
           cross build --release --target aarch64-unknown-linux-gnu
-      - name: Upload linux binaries
+
+      - name: Create linux binary tarballs
         run: |
-          tar -czf target/x86_64-unknown-linux-gnu.tar.gz -C target/x86_64-unknown-linux-gnu/release pks 
-          tar -czf target/aarch64-unknown-linux-gnu.tar.gz -C target/aarch64-unknown-linux-gnu/release pks 
-          gh release upload $NEW_VERSION target/x86_64-unknown-linux-gnu.tar.gz
-          gh release upload $NEW_VERSION target/aarch64-unknown-linux-gnu.tar.gz 
+          tar -czf target/x86_64-unknown-linux-gnu.tar.gz -C target/x86_64-unknown-linux-gnu/release pks
+          tar -czf target/aarch64-unknown-linux-gnu.tar.gz -C target/aarch64-unknown-linux-gnu/release pks
+
+      - name: Sign linux binaries with cosign
+        run: |
+          cosign sign-blob --yes --output-signature target/x86_64-unknown-linux-gnu.tar.gz.sig target/x86_64-unknown-linux-gnu.tar.gz
+          cosign sign-blob --yes --output-signature target/aarch64-unknown-linux-gnu.tar.gz.sig target/aarch64-unknown-linux-gnu.tar.gz
+
+      - name: Upload linux binaries and signatures
+        run: |
+          gh release upload $NEW_VERSION target/x86_64-unknown-linux-gnu.tar.gz target/x86_64-unknown-linux-gnu.tar.gz.sig
+          gh release upload $NEW_VERSION target/aarch64-unknown-linux-gnu.tar.gz target/aarch64-unknown-linux-gnu.tar.gz.sig
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ needs.release.outputs.new_version }}


### PR DESCRIPTION
## Summary  
- Add cosign binary signing to release workflow using GitHub OIDC
- Sign all release artifacts with keyless signing via sigstore
- Upload `.sig` signature files alongside release binaries

## Changes
- `.github/workflows/ci.yml`: Add cosign installation and signing steps
- Sign pks-mac.tar.gz, x86_64-unknown-linux-gnu.tar.gz, aarch64-unknown-linux-gnu.tar.gz

## Security Benefits
- Supply chain security via cryptographic signatures  
- Keyless signing leverages GitHub's identity for verification
- Compatible with `cosign verify` toolchain

## Test Plan
- [x] Local workflow validation passes
- [ ] CI artifact signing verification
- [ ] End-to-end signature validation

Part of PKS release process modernization (atomic PR #2/4).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>