### PR TITLE
Add cargo-audit security scanning to CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,7 +2,7 @@ name: Security audit
 
 on:
   schedule:
-    - cron: 0 0 * * 1
+    - cron: '0 0 * * 1'
   push:
     paths:
       - '**/Cargo.toml'
@@ -13,7 +13,10 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run security audit
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,26 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features
 
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run security audit
+        run: cargo audit
+
   release:
     runs-on: macos-latest
     needs:
       - test
       - lints
       - check
+      - security-audit
     outputs:
       new_version: ${{ steps.check_for_version_changes.outputs.new_version }}
       changed: ${{ steps.check_for_version_changes.outputs.changed }}


### PR DESCRIPTION
## Summary
- Integrate cargo-audit as required CI check before releases
- Update audit.yml workflow to use modern tooling  
- Add security-audit job as dependency for release jobs

## Changes
- `.github/workflows/ci.yml`: Add security-audit job, make release depend on it
- `.github/workflows/audit.yml`: Replace deprecated actions-rs/audit-check with cargo-audit

## Security Benefits
- Block releases with known security vulnerabilities
- Continuous security monitoring of dependencies
- Modern cargo-audit tooling with better performance

## Test Plan
- [x] Local `cargo audit` passes with no vulnerabilities
- [ ] CI security gate validation
- [ ] Verify release blocking on audit failures

Part of PKS release process modernization (atomic PR #3/4).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>