### PR TITLE
Add release-plz automation for changelog management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run cargo check
         run: cargo check
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run cargo test with backtrace
         run: cargo test -- --nocapture
@@ -45,125 +45,10 @@ jobs:
       RUSTFLAGS: "-Dwarnings"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features
-
-  release:
-    runs-on: macos-latest
-    needs:
-      - test
-      - lints
-      - check
-    outputs:
-      new_version: ${{ steps.check_for_version_changes.outputs.new_version }}
-      changed: ${{ steps.check_for_version_changes.outputs.changed }}
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # https://stackoverflow.com/questions/65944700/how-to-run-git-diff-in-github-actions
-          # TLDR – By default this action fetches no history.
-          # We need a bit of history to be able to check if we've recently updated the version in Cargo.toml
-          fetch-depth: 2
-      - name: Toolchain info
-        run: |
-          cargo --version --verbose
-          rustc --version
-          cargo clippy --version
-      - name: Build
-        run: cargo build --release --target aarch64-apple-darwin --target x86_64-apple-darwin
-      - name: Check for version changes in Cargo.toml
-        id: check_for_version_changes
-        run: |
-          # When there are no changes, VERSION_CHANGES will be empty
-          # Without the echo, this command would exit with a 1, causing the GitHub Action to fail
-          # Instead, we want it to succeed, but just evaluate `changed=false` in the other branch of the conditional
-          VERSION_CHANGES=$(git diff HEAD~1 HEAD Cargo.toml | grep "\+version" || echo "")
-          if [[ -n $VERSION_CHANGES ]]; then
-            NEW_VERSION=$(echo $VERSION_CHANGES | awk -F'"' '{print $2}')
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "new_version=v$NEW_VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create GitHub Release if current commit has updated the version in Cargo.toml
-        if: steps.check_for_version_changes.outputs.changed == 'true'
-        run: |
-          gh release create ${{steps.check_for_version_changes.outputs.new_version}} --target "${{ github.sha }}" --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  upload-mac-universal-bin:
-    needs: release
-    runs-on: macos-latest
-    if: ${{needs.release.outputs.new_version}}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --release --target aarch64-apple-darwin --target x86_64-apple-darwin
-
-      - name: Upload mac universal binary
-        run: |
-          # This combines the intel and m1 binaries into a single binary
-          lipo -create -output target/pks target/aarch64-apple-darwin/release/pks target/x86_64-apple-darwin/release/pks
-
-          # Creates artifact for homebrew. -C means run from `target` directory
-          tar -czf target/pks-mac.tar.gz -C target pks
-
-          # This tarball is a binary that is executable
-          gh release upload $NEW_VERSION target/pks-mac.tar.gz
-
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_VERSION: ${{ needs.release.outputs.new_version }}
-
-  upload-linux-bin:
-    needs: release
-    if: ${{needs.release.outputs.new_version}}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update local toolchain
-        run: |
-          cargo install cross
-      - name: Build linux binaries
-        run: |
-          cross build --release --target x86_64-unknown-linux-gnu
-          cross build --release --target aarch64-unknown-linux-gnu
-      - name: Upload linux binaries
-        run: |
-          tar -czf target/x86_64-unknown-linux-gnu.tar.gz -C target/x86_64-unknown-linux-gnu/release pks 
-          tar -czf target/aarch64-unknown-linux-gnu.tar.gz -C target/aarch64-unknown-linux-gnu/release pks 
-          gh release upload $NEW_VERSION target/x86_64-unknown-linux-gnu.tar.gz
-          gh release upload $NEW_VERSION target/aarch64-unknown-linux-gnu.tar.gz 
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_VERSION: ${{ needs.release.outputs.new_version }}
-
-  generate-dotslash-files:
-    name: Generating and uploading DotSlash files
-    needs: 
-      - release
-      - upload-linux-bin
-      - upload-mac-universal-bin
-    if: success() && ${{needs.release.outputs.new_version}}
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: facebook/dotslash-publish-release@v1
-        # This is necessary because the action uses
-        # `gh release upload` to publish the generated DotSlash file(s)
-        # as part of the release.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Additional file that lives in your repo that defines
-          # how your DotSlash file(s) should be generated.
-          config: .github/workflows/dotslash-config.json
-          # Tag for the release to target.
-          tag: ${{ needs.release.outputs.new_version }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,68 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  upload-mac-universal-bin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build macOS binaries
+        run: cargo build --release --target aarch64-apple-darwin --target x86_64-apple-darwin
+
+      - name: Create universal binary and upload
+        run: |
+          # Combine intel and m1 binaries into a single universal binary
+          lipo -create -output target/pks target/aarch64-apple-darwin/release/pks target/x86_64-apple-darwin/release/pks
+
+          # Create tarball for homebrew
+          tar -czf target/pks-mac.tar.gz -C target pks
+
+          # Upload to release
+          gh release upload ${{ github.event.release.tag_name }} target/pks-mac.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-linux-bin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Build linux binaries
+        run: |
+          cross build --release --target x86_64-unknown-linux-gnu
+          cross build --release --target aarch64-unknown-linux-gnu
+
+      - name: Upload linux binaries
+        run: |
+          tar -czf target/x86_64-unknown-linux-gnu.tar.gz -C target/x86_64-unknown-linux-gnu/release pks
+          tar -czf target/aarch64-unknown-linux-gnu.tar.gz -C target/aarch64-unknown-linux-gnu/release pks
+          gh release upload ${{ github.event.release.tag_name }} target/x86_64-unknown-linux-gnu.tar.gz
+          gh release upload ${{ github.event.release.tag_name }} target/aarch64-unknown-linux-gnu.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  generate-dotslash-files:
+    name: Generate DotSlash files
+    needs:
+      - upload-linux-bin
+      - upload-mac-universal-bin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: facebook/dotslash-publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .github/workflows/dotslash-config.json
+          tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,28 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,19 @@
+[workspace]
+# Don't publish to crates.io - binaries are distributed via GitHub releases
+publish = false
+# Create GitHub releases when release PR is merged
+git_release_enable = true
+# Generate changelog from conventional commits
+changelog_update = true
+
+[changelog]
+# Use conventional commits to generate changelog
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore", group = "Miscellaneous" },
+]


### PR DESCRIPTION
## Summary
- Add release-plz workflow for automated version bumps and changelog generation
- Create release-binaries.yml for building artifacts on release publish
- Configure changelog generation from conventional commits

## Changes  
- `.github/workflows/release-plz.yml`: Automated release PR creation
- `.github/workflows/release-binaries.yml`: Binary builds on release publish
- `release-plz.toml`: Configuration for changelog and versioning
- `.github/workflows/ci.yml`: Remove manual release logic

## Automation Benefits
- Conventional commit-based changelog generation
- Automated version bumping following semver
- Streamlined release process with proper artifact builds

## Test Plan
- [x] Local release-plz configuration validation
- [ ] Release PR creation testing  
- [ ] Binary build workflow validation

Part of PKS release process modernization (atomic PR #4/4).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>