### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Welcome! Please see https://github.com/rubyatscale/pks for more information!"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version from `0.3.0` to `0.4.0` to trigger the release workflow for #22 (gitignore support)

## Test plan

- [ ] CI passes
- [ ] On merge, the release job detects the version change and cuts a `v0.4.0` GitHub release with mac + linux binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)